### PR TITLE
Fix Taichi instructions

### DIFF
--- a/taichi.html
+++ b/taichi.html
@@ -585,22 +585,8 @@
 
                 <h3>HOW TO INSTALL:</h3>
                 <ol>
-					<li>Open <b>Magisk >> Downloads</b> section.</li>
-					<a target="_blank" href="taichi/1.jpg">
-						<img src="taichi/1.jpg" alt="image" style="width:150px">
-					  </a>
-					  <br>
-					  <font size="1"><b>click image to enlarge</b></font>
-					  <br>
-
-					<li>Search for <b>"TaiChi"</b>, tap download icon then tap <b>install</b> then <b>Reboot</b>.</li>
-					<a target="_blank" href="taichi/2-3.jpg">
-						<img src="taichi/2-3.jpg" alt="image" style="width:250px">
-					  </a>
-					  <br>
-					  <font size="1"><b>click image to enlarge</b></font>
-					  <br>
-
+					<li>Download the Taichi Magisk Module. Click <a href="https://github.com/taichi-framework/TaiChi-Magisk/releases" target="_blank">HERE</a> to download.</li>
+					<li>Install the Module on Magisk by opening the Manager >> Modules >> + >> Select the .zip file you downloaded</li>
 					<li>Install <b>"TaiChi"</b> app. Click <a href="https://github.com/taichi-framework/TaiChi/releases" target="_blank">HERE</a> to download.</li>
 					
 					


### PR DESCRIPTION
Taichi module is no longer in the magisk repo. Added small instructions on how to get the module now. Could be improved with better instructions but this is just a quick fix.